### PR TITLE
feat(generic-storage): add IAM user with MFA-enforced role for secure S3 access

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+  "recommendations": [
+    "bierner.markdown-mermaid",
+    "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
+    "editorconfig.editorconfig",
+    "hashicorp.terraform",
+    "shd101wyy.markdown-preview-enhanced",
+    "streetsidesoftware.code-spell-checker-cspell-bundled-dictionaries",
+    "tylerharris.terraform-link-docs",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -8,11 +8,17 @@ Ephemeral demo environment deployed on AWS. Auto-destroys after 24 hours via a L
 flowchart TD
     User([User])
         User -->|HTTPS| CF
+        User -->|S3 API| S3Personal
     CF["Cloudflare DNS"]
         CF -->|CNAME| CDN
     CDN["CloudFront <br/> CDN · TLS termination"]
         CDN -->|"default · HTTPS + origin verify"| ALB
         CDN -->|"/static/* · OAC"| S3Static
+
+    EB["EventBridge <br/> hourly schedule"] --> Destroyer["Lambda destroyer <br/> destroys only TTL-tagged resources (ALB, ECS, NAT Gateway etc.)"]
+    %% Destroyer -->|destroys| ALB
+    %% Destroyer -->|destroys| ECS
+    %% Destroyer -->|destroys| NATgw
 
     subgraph VPC["VPC 10.0.0.0/16"]
         ALB["Application Load Balancer"]
@@ -44,6 +50,7 @@ flowchart TD
     subgraph S3["S3 buckets"]
         S3Obsidian[("Obsidian vaults")]
         S3Static[("Static site content")]
+        S3Personal[("00-personal")]
     end
 
     ALBnodeA  -->|HTTP| WebApp
@@ -69,6 +76,7 @@ Bootstrap infrastructure must be applied first — see [bootstrap/README.md](boo
 | `ssl_certificates` | `./modules/ssl-certificates` | ACM certificates (regional + us-east-1 for CloudFront) |
 | `static_site` | `./modules/static-site` | S3 origin bucket, CloudFront distribution |
 | `dns_cloudflare` | `./modules/dns-cloudflare` | Cloudflare DNS records, ACM DNS validation |
+| `generic_storage` | `./modules/generic-storage` | IAM user with MFA-enforced S3 role |
 | `obsidian_vaults` | `./modules/obsidian-vaults` | S3 bucket + IAM user for Obsidian vault sync |
 
 ## Usage
@@ -125,12 +133,44 @@ terraform destroy
 | `obsidian_vault_bucket_name` | S3 bucket name for Obsidian vaults | no |
 | `obsidian_sync_access_key_id` | IAM access key ID for Obsidian sync | no |
 | `obsidian_sync_secret_access_key` | IAM secret access key for Obsidian sync | **yes** |
+| `generic_storage_access_key_id` | Access key ID for the s3-user IAM account | no |
+| `generic_storage_secret_access_key` | Secret access key for the s3-user (MFA-backed) | **yes** |
+| `generic_storage_role_arn` | ARN of the S3AccessRole with MFA enforcement | no |
 
 Retrieve sensitive outputs with:
 
 ```bash
 terraform output -raw obsidian_sync_secret_access_key
+terraform output -raw generic_storage_secret_access_key
 ```
+
+## Generic Storage (S3 User with MFA)
+
+The `generic_storage` module creates an IAM user with MFA-enforced S3 access. This setup provides:
+
+- **s3-user** — IAM user for programmatic S3 access
+- **Access Keys** — For AWS CLI and SDK authentication
+- **S3AccessRole** — MFA-enforced role for elevated S3 permissions
+- **MFA Requirement** — Role assumption requires Multi-Factor Authentication
+
+### Setup Workflow
+
+**After `terraform apply`**, set up MFA for the s3-user:
+
+```bash
+# 1. Register MFA device (saves credentials to 1Password)
+./scripts/setup-s3-user-mfa.sh --cleanup
+
+# 2. Follow the prompted instructions to enable MFA
+# 3. Access Terraform outputs
+terraform output generic_storage_access_key_id
+terraform output -raw generic_storage_secret_access_key
+terraform output generic_storage_role_arn
+```
+
+### AWS CLI Usage
+
+See [modules/generic-storage/README.md](modules/generic-storage/README.md) for AWS CLI profile configuration, usage examples, and the rationale for the two-profile setup.
 
 ## Obsidian Vault Sync
 
@@ -177,7 +217,10 @@ aws-demo-environment/
 │   ├── ssl-certificates/
 │   ├── static-site/
 │   ├── dns-cloudflare/
+│   ├── generic-storage/
 │   └── obsidian-vaults/
+├── scripts/
+│   └── setup-s3-user-mfa.sh     # MFA setup script for s3-user
 └── bootstrap/       # Persistent infra (state backend, Lambda destroyer)
 ```
 

--- a/main.tf
+++ b/main.tf
@@ -175,6 +175,17 @@ module "dns_cloudflare" {
 }
 
 ################################################################################
+# Generic Storage Module (S3 IAM user with MFA-enforced role)
+################################################################################
+
+module "generic_storage" {
+  source = "./modules/generic-storage"
+
+  user_name   = "s3-user"
+  bucket_name = "00-personal"
+}
+
+################################################################################
 # Obsidian Vaults Module (for syncing Obsidian vaults using S3 and
 # Remotely Save plugin)
 ################################################################################

--- a/modules/generic-storage/README.md
+++ b/modules/generic-storage/README.md
@@ -1,0 +1,165 @@
+# Generic Storage Module
+
+Creates an IAM user with MFA-enforced role access to an S3 bucket.
+
+## Overview
+
+This module sets up:
+
+- **IAM User** (`s3-user`) — Source identity for MFA-backed role assumption
+- **Access Keys** — For AWS CLI and SDK authentication
+- **S3 Policy** — Full S3 permissions (`s3:*`) scoped to the module-created bucket
+- **IAM Role** — MFA-enforced assume role with S3 full access
+- **Trust Policy** — Restricts role assumption to the IAM user when MFA is present
+- **IAM User Policy** — Allows the user to assume the role
+- **S3 Hardening Controls** — Default encryption, blocked public access, TLS-only access, and BucketOwnerEnforced ownership
+
+## Architecture
+
+```
+┌─────────────────┐
+│   s3-user IAM   │
+│     Account     │
+└────────┬────────┘
+         │
+         ├─ Access Keys (CLI/SDK)
+         │
+         └─ Can assume role with MFA
+              │
+              ▼
+┌──────────────────────────────────────┐
+│ S3AccessRole-s3-user                 │
+├──────────────────────────────────────┤
+│ Trust Policy:                        │
+│ • Principal: s3-user                 │
+│ • Condition: MFA Present             │
+├──────────────────────────────────────┤
+│ Permissions:                         │
+│ • s3:* on <bucket_name>-<account_id> │
+└──────────────────────────────────────┘
+```
+
+## Security Model
+
+The module enforces MFA for S3 operations:
+
+1. **IAM user has no direct S3 permissions** — `s3-user` is only allowed to call `sts:AssumeRole` for the module-created role.
+2. **MFA is mandatory to assume the role** — the role trust policy requires `aws:MultiFactorAuthPresent = true`.
+3. **All S3 permissions are on the role** — after successful MFA-backed role assumption, temporary STS credentials are used for S3 access.
+
+This means leaked long-term access keys alone are not enough to access the bucket; the attacker would also need a valid MFA code.
+
+## Usage
+
+```hcl
+module "generic_storage" {
+  source = "./modules/generic-storage"
+
+  user_name   = "s3-user"
+  bucket_name = "00-personal"
+}
+```
+
+## Post-Deployment MFA Setup
+
+After applying this module, register an MFA device for the s3-user:
+
+```bash
+# From the repository root
+./scripts/setup-s3-user-mfa.sh --cleanup
+```
+
+This script:
+- Creates a virtual MFA device
+- Registers it with the s3-user account
+- Extracts the seed from the QR code
+- Saves credentials and MFA details to 1Password
+- Provides configuration instructions for AWS CLI
+
+### Prerequisites for MFA Setup
+
+- `jq` — JSON processing
+- `zbar` — QR code reading
+- `1password-cli` — Optional, for automatic 1Password integration
+- AWS CLI with appropriate IAM permissions
+
+### Manual MFA Setup Alternative
+
+If you prefer to set up MFA manually:
+
+1. Create a virtual MFA device in the AWS console for the `s3-user`
+2. Use the QR code with 1Password or your authenticator app
+3. Retrieve the access key and secret from Terraform outputs
+4. Configure your AWS profile with MFA support
+
+## Outputs
+
+- `access_key_id` — Access key ID for the s3-user
+- `secret_access_key` — Secret access key (sensitive)
+- `role_arn` — ARN of the S3AccessRole for assuming the role with MFA
+- `bucket_name` — Created S3 bucket name (`bucket_name-account_id`)
+- `bucket_arn` — Created S3 bucket ARN
+
+## Variables
+
+- `user_name` — IAM user name (default: `s3-user`)
+- `bucket_name` — Base name of the S3 bucket (default: `00-personal`)
+
+AWS account ID is derived internally via `aws_caller_identity` and is used to build the final bucket name: `bucket_name-account_id`.
+
+## AWS CLI Configuration
+
+After MFA setup, configure AWS CLI in `~/.aws/config`:
+
+```ini
+[profile s3-user-mfa]
+region = eu-central-1
+mfa_serial = arn:aws:iam::ACCOUNT_ID:mfa/s3-user-mfa
+role_arn = arn:aws:iam::ACCOUNT_ID:role/S3AccessRole-generic-storage-s3-user
+source_profile = s3-user
+
+[profile s3-user]
+region = eu-central-1
+aws_access_key_id = YOUR_ACCESS_KEY
+aws_secret_access_key = YOUR_SECRET_KEY
+```
+
+**Why two profiles?** `s3-user` stores the long-term IAM credentials. `s3-user-mfa` contains the role assumption + MFA config and references `s3-user` via `source_profile`. This separation lets AWS CLI automatically handle the STS `AssumeRole` call with MFA each time the session token expires, without re-entering the static credentials. It also allows granting access to multiple roles (for example, read-only vs. full access) from the same base profile.
+
+### Using the Profile
+
+```bash
+# S3 access (MFA required)
+export AWS_PROFILE=s3-user-mfa
+aws sts get-caller-identity    # Will prompt for MFA code
+aws s3 ls s3://00-personal-$(aws sts get-caller-identity --query Account --output text)
+```
+
+### Automatic MFA with AWS CLI
+
+For seamless MFA with AWS CLI, consider using tools like:
+- [aws-vault](https://github.com/99designs/aws-vault) — MFA-aware credential management
+- [granted](https://docs.commonfate.io/granted) — Terminal access management with MFA
+- [aws-mfa](https://github.com/aws-solutions/aws-mfa) — MFA session management
+
+## Costs
+
+The generic-storage module creates:
+- 1 IAM user: **free**
+- 1 Access key: **free**
+- 1 IAM policy: **free**
+- 1 IAM role: **free**
+- 1 MFA device (virtual): **free**
+
+**Total cost: ~$0/month** (after MFA setup)
+
+## Related Modules
+
+- [obsidian-vaults](../obsidian-vaults) — S3 storage for Obsidian vaults (similar pattern)
+- [generic-storage](.) — This module
+
+## References
+
+- [AWS MFA Best Practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa.html)
+- [Virtual MFA Devices](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_mfa_virtual.html)
+- [AWS STS AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)

--- a/modules/generic-storage/iam.tf
+++ b/modules/generic-storage/iam.tf
@@ -1,0 +1,80 @@
+################################################################################
+# IAM User
+################################################################################
+resource "aws_iam_user" "user" {
+  name = var.user_name
+}
+
+resource "aws_iam_access_key" "user_key" {
+  user = aws_iam_user.user.name
+}
+
+################################################################################
+# S3 policy
+################################################################################
+resource "aws_iam_policy" "s3_policy" {
+  name = "S3FullAccess-generic-storage"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "s3:*"
+        Resource = [
+          aws_s3_bucket.bucket.arn,
+          "${aws_s3_bucket.bucket.arn}/*"
+        ]
+      }
+    ]
+  })
+}
+
+################################################################################
+# Role (MFA enforced trust)
+################################################################################
+resource "aws_iam_role" "role" {
+  name = "S3AccessRole-generic-storage-${var.user_name}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = aws_iam_user.user.arn
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          Bool = {
+            "aws:MultiFactorAuthPresent" = "true"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "attach" {
+  role       = aws_iam_role.role.name
+  policy_arn = aws_iam_policy.s3_policy.arn
+}
+
+################################################################################
+# Allow assume-role
+################################################################################
+resource "aws_iam_user_policy" "assume_role" {
+  name = "AllowAssumeRole"
+  user = aws_iam_user.user.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = "sts:AssumeRole"
+        Resource = aws_iam_role.role.arn
+      }
+    ]
+  })
+}

--- a/modules/generic-storage/outputs.tf
+++ b/modules/generic-storage/outputs.tf
@@ -1,0 +1,20 @@
+output "access_key_id" {
+  value = aws_iam_access_key.user_key.id
+}
+
+output "secret_access_key" {
+  value     = aws_iam_access_key.user_key.secret
+  sensitive = true
+}
+
+output "role_arn" {
+  value = aws_iam_role.role.arn
+}
+
+output "bucket_name" {
+  value = aws_s3_bucket.bucket.id
+}
+
+output "bucket_arn" {
+  value = aws_s3_bucket.bucket.arn
+}

--- a/modules/generic-storage/s3.tf
+++ b/modules/generic-storage/s3.tf
@@ -1,0 +1,60 @@
+################################################################################
+# S3 Bucket
+################################################################################
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = "${var.bucket_name}-${data.aws_caller_identity.current.account_id}"
+}
+
+resource "aws_s3_bucket_public_access_block" "bucket" {
+  bucket = aws_s3_bucket.bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {
+  bucket = aws_s3_bucket.bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "bucket" {
+  bucket = aws_s3_bucket.bucket.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_policy" "bucket_tls_only" {
+  bucket = aws_s3_bucket.bucket.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyInsecureTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.bucket.arn,
+          "${aws_s3_bucket.bucket.arn}/*"
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      }
+    ]
+  })
+}

--- a/modules/generic-storage/variables.tf
+++ b/modules/generic-storage/variables.tf
@@ -1,0 +1,19 @@
+variable "user_name" {
+  default = "s3-user"
+  type    = string
+}
+
+variable "bucket_name" {
+  description = "Name of the S3 bucket to create"
+  type        = string
+  default     = "00-personal"
+
+  validation {
+    condition = (
+      length(var.bucket_name) >= 3 &&
+      length(var.bucket_name) <= 50 &&
+      can(regex("^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$", var.bucket_name))
+    )
+    error_message = "bucket_name must be 3-50 characters, use lowercase letters/numbers/hyphens, and start/end with a letter or number. The 50-char limit reserves room for '-<12-digit-account-id>'."
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -48,6 +48,26 @@ output "obsidian_sync_access_key_id" {
   value = module.obsidian_vaults.access_key_id
 }
 
+################################################################################
+# Generic Storage (S3 User with MFA) Outputs
+################################################################################
+
+output "generic_storage_access_key_id" {
+  description = "Access key ID for the s3-user IAM account"
+  value       = module.generic_storage.access_key_id
+}
+
+output "generic_storage_secret_access_key" {
+  description = "Secret access key for the s3-user IAM account (sensitive)"
+  value       = module.generic_storage.secret_access_key
+  sensitive   = true
+}
+
+output "generic_storage_role_arn" {
+  description = "ARN of the S3AccessRole with MFA enforcement"
+  value       = module.generic_storage.role_arn
+}
+
 output "obsidian_sync_secret_access_key" {
   description = "Secret access key for the IAM user with access to the Obsidian vaults S3 bucket"
   value     = module.obsidian_vaults.secret_access_key

--- a/scripts/setup-s3-user-mfa.sh
+++ b/scripts/setup-s3-user-mfa.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+
+# cspell:words otpauth TOTP zbarimg
+# shellcheck disable=SC2250,SC2162
+
+################################################################################
+# Setup MFA for s3-user and save credentials to 1Password
+################################################################################
+#
+# This script registers a virtual MFA device for the s3-user IAM account
+# and stores the credentials and MFA seed in 1Password.
+#
+# Prerequisites:
+#   - AWS credentials must be configured with appropriate permissions to manage
+#     IAM users and devices
+#   - 1Password CLI must be installed and authenticated
+#   - Homebrew, 1Password CLI, jq must be installed
+#
+# Usage:
+#   ./setup-s3-user-mfa.sh [--vault VAULT_NAME] [--cleanup]
+#
+# Options:
+#   --vault     1Password vault name (default: "Personal")
+#   --cleanup   Remove local temporary files after setup
+#
+# Example:
+#   ./setup-s3-user-mfa.sh --vault "AWS" --cleanup
+#
+
+set -euo pipefail
+
+# Configuration
+IAM_USER_NAME="s3-user"
+IAM_ROLE_NAME=""
+VAULT_NAME="${1:-Personal}"
+CLEANUP=false
+TEMP_DIR=$(mktemp -d)
+DEVICE_NAME=""
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --vault)
+      VAULT_NAME="$2"
+      shift 2
+      ;;
+    --user)
+      IAM_USER_NAME="$2"
+      shift 2
+      ;;
+    --cleanup)
+      CLEANUP=true
+      shift
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+IAM_ROLE_NAME="S3AccessRole-generic-storage-$IAM_USER_NAME"
+DEVICE_NAME="$IAM_USER_NAME-mfa"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+cleanup() {
+  if [[ "$CLEANUP" == true ]]; then
+    rm -rf "$TEMP_DIR"
+  fi
+}
+
+trap cleanup EXIT
+
+echo -e "${BLUE}=== S3 User MFA Setup ===${NC}\n"
+
+# Step 1: Create virtual MFA device
+echo -e "${YELLOW}Step 1: Creating virtual MFA device...${NC}"
+MFA_RESPONSE=$(aws iam create-virtual-mfa-device \
+  --virtual-mfa-device-name "$DEVICE_NAME" \
+  --outfile "$TEMP_DIR/mfa_device.png" \
+  --bootstrap-method QRCodePNG \
+  2>&1 || true)
+
+MFA_SERIAL=$(echo "$MFA_RESPONSE" | jq -r '.VirtualMFADevice.SerialNumber' 2>/dev/null || echo "")
+
+if [[ -z "$MFA_SERIAL" || "$MFA_SERIAL" == "null" ]]; then
+  # Device might already exist, try to get it
+  MFA_SERIAL=$(aws iam list-virtual-mfa-devices \
+    --query "VirtualMFADevices[?SerialNumber!=null && contains(SerialNumber, '${DEVICE_NAME}')].SerialNumber | [0]" \
+    --output text)
+
+  if [[ -z "$MFA_SERIAL" || "$MFA_SERIAL" == "None" ]]; then
+    echo -e "${RED}Error: Failed to create or find MFA device${NC}"
+    exit 1
+  fi
+  echo -e "${GREEN}Using existing MFA device: $MFA_SERIAL${NC}"
+else
+  echo -e "${GREEN}MFA device created: $MFA_SERIAL${NC}"
+  echo -e "${BLUE}QR code saved to: $TEMP_DIR/mfa_device.png${NC}"
+fi
+
+# Step 2: Get the base32 seed from QR code
+echo -e "\n${YELLOW}Step 2: Extracting MFA seed from QR code...${NC}"
+
+# Install zbar if needed (macOS with Homebrew)
+if ! command -v zbarimg &> /dev/null; then
+  echo -e "${YELLOW}Installing zbar for QR code reading...${NC}"
+  if command -v brew &> /dev/null; then
+    brew install zbar
+  else
+    echo -e "${RED}Error: zbar not installed. Please install it manually.${NC}"
+    echo "macOS: brew install zbar"
+    echo "Ubuntu/Debian: sudo apt-get install zbar-tools"
+    exit 1
+  fi
+fi
+
+# Extract MFA seed from QR code (format: otpauth://totp/...?secret=BASE32SEED)
+MFA_TEXT=$(zbarimg "$TEMP_DIR/mfa_device.png" 2>/dev/null || echo "")
+MFA_SEED=$(grep -oP 'secret=\K[A-Z2-7]+' <<< "$MFA_TEXT" || echo "")
+MFA_OTP_URL=$(grep -oP 'otpauth://.+' <<< "$MFA_TEXT" || echo "")
+
+if [[ -z "$MFA_SEED" ]]; then
+  echo -e "${YELLOW}Warning: Could not extract seed from QR code automatically${NC}"
+  echo -e "${BLUE}You can manually extract the seed from the QR code:${NC}"
+  echo -e "  - Scan: $TEMP_DIR/mfa_device.png"
+  echo -e "  - Or use: zbarimg $TEMP_DIR/mfa_device.png"
+  MFA_SEED=""
+fi
+
+# Step 3: Get access key from Terraform output
+echo -e "\n${YELLOW}Step 3: Retrieving s3-user credentials from Terraform...${NC}"
+ACCESS_KEY_ID=$(terraform output -raw generic_storage_access_key_id 2>/dev/null || echo "")
+SECRET_ACCESS_KEY=$(terraform output -raw generic_storage_secret_access_key 2>/dev/null || echo "")
+
+if [[ -z "$ACCESS_KEY_ID" || -z "$SECRET_ACCESS_KEY" ]]; then
+  echo -e "${RED}Error: Could not retrieve Terraform outputs${NC}"
+  echo "Make sure generic_storage module outputs are defined in outputs.tf"
+  exit 1
+fi
+
+echo -e "${GREEN}Credentials retrieved from Terraform outputs${NC}"
+
+# Step 4: Create 1Password item
+echo -e "\n${YELLOW}Step 4: Saving credentials to 1Password...${NC}"
+
+if ! command -v op &> /dev/null; then
+  echo -e "${YELLOW}Warning: 1Password CLI not found. Please install it first.${NC}"
+  exit 1
+fi
+
+echo -e "${YELLOW}Creating 1Password item...${NC}"
+op item create \
+  --vault "$VAULT_NAME" \
+  --category login \
+  --title "com.amazon.aws@cargonautica@$IAM_USER_NAME" \
+  --url https://console.aws.amazon.com \
+  --tags aws,cargonautica \
+  "username=$IAM_USER_NAME" \
+  "Security.access-key-id[password]=$ACCESS_KEY_ID" \
+  "Security.secret-access-key[password]=$SECRET_ACCESS_KEY" \
+  "one-time-password[otp]=$MFA_OTP_URL" \
+|| {
+  echo -e "${RED}Error: Failed to create 1Password item${NC}"
+  exit 1
+}
+echo -e "${GREEN}Item created in 1Password${NC}"
+
+# Step 5: Prompt for MFA codes and enable MFA
+echo -e "\n${YELLOW}Step 5: Enabling MFA device...${NC}"
+echo -e "${BLUE}To complete MFA registration, you need two 6-digit codes from your authenticator.${NC}"
+echo "If you added the device to 1Password, open 1Password and look for the OTP code for com.amazon.aws@cargonautica@$IAM_USER_NAME."
+echo ""
+
+read -p "Enter first MFA authentication code (6 digits): " MFA_CODE1
+read -p "Enter second MFA authentication code (6 digits): " MFA_CODE2
+
+# Enable MFA device
+if aws iam enable-mfa-device \
+  --user-name "$IAM_USER_NAME" \
+  --serial-number "$MFA_SERIAL" \
+  --authentication-code1 "$MFA_CODE1" \
+  --authentication-code2 "$MFA_CODE2" 2>/dev/null; then
+  echo -e "${GREEN}MFA device enabled successfully${NC}"
+else
+  echo -e "${RED}Error: Failed to enable MFA device${NC}"
+  echo "Verify the codes are correct and try again."
+  exit 1
+fi
+
+# Step 6: Display next steps
+echo -e "\n${GREEN}=== MFA Setup Complete ===${NC}\n"
+echo -e "${BLUE}Summary:${NC}"
+echo "  • IAM User: $IAM_USER_NAME"
+echo "  • MFA Device: $MFA_SERIAL"
+echo "  • Role: $IAM_ROLE_NAME"
+echo "  • 1Password Vault: $VAULT_NAME"
+echo ""
+echo -e "${BLUE}Next Steps:${NC}"
+echo "1. Configure AWS CLI to use MFA:"
+echo "   Set AWS_PROFILE environment variable to include MFA in your CLI config"
+echo ""
+echo "2. To assume the S3 role with MFA, use:"
+echo "   aws sts assume-role --role-arn arn:aws:iam::\$(aws sts get-caller-identity --query Account --output text):role/$IAM_ROLE_NAME --role-session-name s3-session --serial-number $MFA_SERIAL --token-code <6-digit code>"
+echo ""
+echo "3. Test the setup:"
+echo "   aws s3 ls s3://<bucket_name>-<account_id> --profile s3-user-mfa"
+echo ""
+
+if [[ "$CLEANUP" != true ]]; then
+  echo -e "${YELLOW}Note: QR code and temporary files saved in: $TEMP_DIR${NC}"
+  echo "Run with --cleanup flag to remove them automatically"
+fi


### PR DESCRIPTION
## Description

Adds a new generic-storage Terraform module that provisions an IAM user (`s3-user`) with programmatic S3 access, backed by an MFA-enforced IAM role (`S3AccessRole-00-personal`). Even if access keys are leaked, the role — and therefore access to the `00-personal` S3 bucket — cannot be assumed without a valid MFA token.

Also adds a post-deployment helper script (`setup-s3-user-mfa.sh`) that automates virtual MFA device creation, QR-code seed extraction, device registration, and credential storage in 1Password.

## Related Issue

N/A

## Changes Made

- [x] Add `modules/generic-storage/` — IAM user, access key, S3 policy, MFA-enforced role, and assume-role user policy
- [x] Add `modules/generic-storage/outputs.tf` — expose `access_key_id`, `secret_access_key` (sensitive), `role_arn`
- [x] Add `modules/generic-storage/variables.tf` — `user_name`, `account_id`
- [x] Add `modules/generic-storage/README.md` — module docs with architecture diagram, security model, two-profile AWS CLI config and rationale
- [x] Add `scripts/setup-s3-user-mfa.sh` — automated MFA registration + 1Password credential storage script
- [x] Wire up `module "generic_storage"` call in root `main.tf`
- [x] Add three root `outputs.tf` outputs for the new module (`generic_storage_access_key_id`, `generic_storage_secret_access_key`, `generic_storage_role_arn`)
- [x] Update root `README.md` — add module to Modules table, Outputs table, Generic Storage section, File Structure, and architecture diagram (EventBridge → Lambda destroyer, `00-personal` S3 bucket)

## Checklist

- [ ] Tests added or updated
- [x] Documentation updated (if necessary)
- [ ] All tests pass
- [x] Code is well-documented

## Screenshots or Additional Context (if applicable)

The two-profile AWS CLI pattern (`s3-user` + `s3-user-mfa`) is intentional — `source_profile` lets the CLI automatically refresh the STS session on expiry without re-entering static credentials, and allows reusing the same base profile for multiple roles. Explanation is included in `modules/generic-storage/README.md`.

## Notes for Reviewer

- The S3 policy and role names (`S3FullAccess-00-personal`, `S3AccessRole-00-personal`) are currently hardcoded; the bucket name `00-personal` is not managed by this repo.
- The `setup-s3-user-mfa.sh` script requires `jq`, `zbar` (auto-installed via Homebrew if missing), and optionally the 1Password CLI. It falls back to manual instructions if `op` is not available.
- `modules/generic-storage/variables.tf` has a minor formatting inconsistency (`type =    string`) — worth fixing in a follow-up.