### PR TITLE
chore(cspell): add CSpell configuration and dictionary

### DIFF
--- a/.cspell.config.yaml
+++ b/.cspell.config.yaml
@@ -1,0 +1,21 @@
+version: "0.2"
+language: en
+
+import:
+  - "${userHome}/.cspell.config.yaml"
+
+dictionaryDefinitions:
+  - name: project-words
+    path: ./.cspell/project-words.txt
+    addWords: true
+
+dictionaries:
+  - aws
+  - project-words
+  - terraform
+
+useGitignore: true
+
+ignorePaths:
+  - "**/node_modules/**"
+  - "**/dist/**"

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -1,0 +1,22 @@
+# Local project dictionary words
+# One word per line
+
+cargonautica
+cloudflare
+fargate
+hostnames
+mgmt
+obsidian
+tflock
+turboBasic
+unproxied
+zbar
+
+# AWS API words
+eipalloc
+elbv
+eventbridge
+keepalive
+natgateway
+resourcegroupstaggingapi
+targetgroup

--- a/modules/static-site/README.md
+++ b/modules/static-site/README.md
@@ -167,6 +167,7 @@ aws cloudfront create-invalidation --distribution-id "$(terraform output -raw cl
 ## Cache Invalidation
 
 When updating static files:
+<!-- cspell:ignore E1E23QKYQBHFUB -->
 
 ```bash
 # Invalidate CloudFront cache


### PR DESCRIPTION
## Description

Adds workspace-level CSpell configuration that respects `.gitignore` rules, imports global user CSpell config, and includes a project-specific dictionary for domain-specific terms.

## Related Issue

N/A

## Changes Made

- [x] Added `.cspell.config.yaml` with workspace CSpell configuration
- [x] Added `.cspell/project-words.txt` local dictionary with project-specific terms

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (if necessary)
- [x] All tests pass
- [x] Code is well-documented

## Screenshots or Additional Context (if applicable)

N/A

## Notes for Reviewer

N/A
