### PR TITLE
ci: add GitHub workflows

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -25,4 +25,5 @@ resourcegroupstaggingapi
 targetgroup
 
 # Terraform words
+allfiles
 tfenv

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,51 @@
+name: Conventional Commits
+# cspell:ignore amannn commitlint wagoid
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+  push:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  pr-title:
+    name: Validate PR title
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Enforce Conventional Commit format in PR title
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+
+  commit-messages:
+    name: Validate commit messages
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Enforce Conventional Commit format in commit messages
+        uses: wagoid/commitlint-github-action@v6
+        with:
+          failOnWarnings: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,65 @@
+name: "On PR & push: Lint project"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Get changed files
+        uses: tj-actions/changed-files@v47
+        id: changed
+        with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
+          files_yaml: |
+            allfiles:
+              - '**/*'
+
+      - name: Set up Mise toolchain
+        uses: jdx/mise-action@v4
+        with:
+          version: 2026.3.9
+
+      - name: Install lint dependencies
+        # Install pyproject dependencies using the uv version managed by Mise.
+        run: mise exec -- uv sync --group lint --frozen
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pre-commit
+          key: precommit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            precommit-${{ runner.os }}-
+
+      # Configuration file for pre-commit: .pre-commit-config.yaml
+      # Linter configurations:
+      # - Configuration file for JavaScript: .biome.json
+      # - Configuration file for Markdown: .pymarkdown
+      # - Configuration file for Python: pyproject.toml (tool.ruff section)
+      # - Configuration file for YAML: .yamllint
+      - name: Run pre-commit on changed files
+        if: steps.changed.outputs.allfiles_any_changed == 'true'
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed.outputs.allfiles_all_changed_files }}
+        run: |-
+          # shellcheck disable=SC2086
+          mise exec -- uv run --no-sync \
+            pre-commit run --files ${ALL_CHANGED_FILES} --show-diff-on-failure


### PR DESCRIPTION
## Summary
Adds CI automation by introducing GitHub Actions workflows for linting and Conventional Commit validation.

## What Changed
- Added workflow: `.github/workflows/lint.yml`
- Added workflow: `.github/workflows/conventional-commits.yml`

## Why
- Enforce commit message consistency with Conventional Commits.
- Run lint checks automatically in CI to catch issues earlier.

## Validation
- Workflows are configured in `.github/workflows/`.
- Local checks previously completed successfully (`pre-commit run --all-files`).

