### PR TITLE
chore(ci): update workflow name for conventional commits

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,4 +1,4 @@
-name: Conventional Commits
+name: "On PR & push: Conventional Commits"
 # cspell:ignore amannn commitlint wagoid
 
 on:


### PR DESCRIPTION
## Description

This PR updates the Conventional Commits workflow title to make its trigger context explicit for reviewers and contributors.

## Changes

- Renamed the workflow display name to: "On PR & push: Conventional Commits"
- Kept workflow behavior unchanged (trigger/configuration logic not modified)

## Testing

- [ ] Unit tests added / updated
- [x] Manually verified

## Checklist

- [x] No secrets or credentials included
- [x] `make lint` passes locally