### PR TITLE
chore: add dependabot and renovate configuration files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "terraform"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "terraform"
+    directory: "/bootstrap"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "schedule": ["before 6am on monday"],
+  "commitMessagePrefix": "chore(deps):",
+  "enabledManagers": ["pep621"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"]
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,8 @@
     },
     "explorerExclude.backup": {},
     "hide-files.files": [],
-    "makefile.configureOnOpen": false
+    "makefile.configureOnOpen": false,
+    "json.schemaDownload.trustedDomains": {
+        "https://docs.renovatebot.com": true
+    }
 }


### PR DESCRIPTION
## Description

Enable automated dependency updates by adding config for two complementary tools:
**Dependabot** for Terraform and GitHub Actions, **Renovate** for Python deps managed by uv.

Ecosystems are split between the two tools to avoid duplicate PRs. Dependabot handles Terraform and Actions (simpler, GitHub-native). Renovate owns the `pep621` manager because Dependabot's `pip` manager does not regenerate `uv.lock` — which would break `make install` (uses `uv sync --frozen`).

## Changes

- Add `.github/dependabot.yml` with three update entries:
  - `terraform` on `/` (root module) — weekly, `chore(deps):` prefix
  - `terraform` on `/bootstrap` — weekly, `chore(deps):` prefix
  - `github-actions` on `/` — weekly, `ci(deps):` prefix
- Add `.github/renovate.json`:
  - Scoped to `enabledManagers: ["pep621"]` so it only touches `pyproject.toml` / `uv.lock`
  - `lockFileMaintenance` enabled to refresh transitive deps weekly
  - `chore(deps):` commit prefix, Monday pre-6am schedule

## Testing

- [ ] Unit tests added / updated
- [x] Manually verified — `pre-commit run --files .github/dependabot.yml .github/renovate.json` passes (yamllint clean)

Post-merge verification:

- [ ] Install the [Renovate GitHub App](https://github.com/apps/renovate) on this repo
- [ ] Close the Renovate onboarding PR (config is already committed)
- [ ] Enable *Dependabot alerts* + *security updates* under **Settings → Code security**
- [ ] Confirm first scheduled run opens PRs with the expected Conventional Commit prefixes

## Checklist

- [x] No secrets or credentials included
- [x] `make lint` passes locally
