### PR TITLE
ci(lint): enable linting of markdown in skills

### DIFF
--- a/.claude/skills/aws/SKILL.md
+++ b/.claude/skills/aws/SKILL.md
@@ -15,6 +15,7 @@ This skill helps configure AWS authentication for the `cargonautica` AWS profile
 ## When to Use
 
 Use this skill **before** running:
+
 - Any AWS CLI commands (`aws s3`, `aws ec2`, etc.)
 - Terraform commands that interact with AWS (`terraform plan`, `terraform apply`, etc.)
 - When authentication errors occur (expired SSO session)
@@ -92,6 +93,7 @@ See [@.claude/scripts/aws-sso-credentials.sh](../../scripts/aws-sso-credentials.
 **Error**: `Error when retrieving token from sso: Token has expired`
 
 **Resolution**: Inform user to re-authenticate:
+
 ```bash
 aws sso login --profile cargonautica
 ```

--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -41,7 +41,7 @@ template at `.github/PULL_REQUEST_TEMPLATE.md`.
 5. **Output** — wrap the completed description in a fenced markdown code block tagged
    `markdown` so the user can copy the raw text in one click:
 
-   ````
+   ````text
    ```markdown
    ## Description
    …
@@ -59,7 +59,7 @@ template at `.github/PULL_REQUEST_TEMPLATE.md`.
 
 ## Example invocation
 
-```
+```text
 /pr-description
 ```
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,6 @@ repos:
           - --config
           - .pymarkdown
           - scan
-        exclude: ^\.claude/skills/[^/]+/SKILL\.md$
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.11.0.1

--- a/.pymarkdown
+++ b/.pymarkdown
@@ -1,4 +1,9 @@
 {
+  "extensions": {
+    "front-matter": {
+      "enabled": true
+    }
+  },
   "plugins": {
     "md013": {
       "enabled": false


### PR DESCRIPTION
## Description

PyMarkdown was silently skipping all `SKILL.md` files because an `exclude` pattern was added to suppress false violations instead of fixing their root cause: pymarkdown was misinterpreting YAML frontmatter `---` delimiters as setext heading markers, causing cascading style errors across all skill files.

## Changes

- `.pymarkdown` — enable the `front-matter` extension so pymarkdown correctly skips YAML frontmatter blocks
- `.pre-commit-config.yaml` — remove the `exclude: ^\.claude/skills/[^/]+/SKILL\.md$` pattern from the pymarkdown hook
- `.claude/skills/aws/SKILL.md` — add blank lines before a list (MD032) and before a code fence (MD031)
- `.claude/skills/pr-description/SKILL.md` — add language tags to two unlabeled code fences (MD040); remove stale test content from the bottom of the file

## Testing

- [ ] Unit tests added / updated
- [x] Manually verified

`pre-commit run --files` confirmed PyMarkdown now runs and passes on all four SKILL.md files.

## Checklist

- [x] No secrets or credentials included
- [x] `make lint` passes locally

