### PR TITLE
chore(ai): enhance PR description generator

### DIFF
--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -1,52 +1,106 @@
 ---
 name: pr-description
-description: Generate a PR description for the current branch using the repo PR template
+description: Generate a PR description, create a feature branch if needed, and submit the PR to GitHub
 user-invocable: true
 model: Sonnet
-allowed-tools: Bash(git log:*), Bash(git diff:*), Bash(git rev-parse:*), Bash(git branch:*), Read
+allowed-tools: Bash(git log:*), Bash(git diff:*), Bash(git rev-parse:*), Bash(git branch:*), Bash(git checkout:*), Bash(git push:*), Bash(gh pr create:*), Bash(gh pr view:*), Read
 ---
 
 # PR Description Generator
 
 ## Purpose
 
-Generate a pull request description for the current branch, filled from the repo's PR
-template at `.github/PULL_REQUEST_TEMPLATE.md`.
+Generate a pull request description filled from the repo's PR template, then create and
+submit the PR on GitHub via `gh pr create`.
+
+Handles two starting states:
+
+- **On a feature branch** — uses the current branch as-is.
+- **On `main`** — derives a branch name from the unmerged commit subjects, creates and
+  pushes that branch, then opens the PR.
 
 ## Steps
 
-1. **Determine the base branch** — default to `main`; if `main` does not exist, fall back
-   to `master`.
+### 1. Identify unmerged commits
 
-2. **Collect the diff** — run `git log` and `git diff` for all commits on this branch that
-   are not yet on the base branch:
+```bash
+git log --oneline origin/main..HEAD
+```
+
+If this produces no output, tell the user there is nothing to PR and stop.
+
+### 2. Determine (or create) the feature branch
+
+**If the current branch is NOT `main`:** use it directly — go to step 3.
+
+**If the current branch IS `main`:**
+
+a. Read the commit subjects from the log above.
+
+b. Derive a branch name from the first (or most representative) commit subject:
+
+- Strip the Conventional Commits prefix (`fix:`, `feat(scope):`, etc.) and any leading punctuation.
+- Lower-case, replace spaces and special characters with `-`, truncate to 50 characters.
+- Prefix with the Conventional Commits type when present: `feat/`, `fix/`, `chore/`, etc.
+- Example: `feat(ci): add actionlint hook` → `feat/add-actionlint-hook`
+
+c. Create and push the branch:
 
    ```bash
-   git log --oneline origin/main..HEAD
-   git diff origin/main...HEAD
+   git checkout -b <derived-branch-name>
+   git push -u origin <derived-branch-name>
    ```
 
-3. **Read the PR template** — read `.github/PULL_REQUEST_TEMPLATE.md` verbatim; this is
-   the skeleton you must fill in.
+### 3. Collect the diff
 
-4. **Fill in the template** — replace every `{{ placeholder }}` and populate every section:
+```bash
+git log --oneline origin/main..HEAD
+git diff origin/main...HEAD
+```
 
-   | Template section | What to write |
-   |-----------------|---------------|
-   | `## Description` | One concise paragraph: *what* changed and *why* (the business/user motivation). No implementation detail. |
-   | `## Changes`    | Bulleted list of concrete changes (files, resources, modules). Be specific — name the files or resources. |
-   | `## Testing`    | Check the boxes that honestly apply; add a note if manual testing was done. |
-   | `## Checklist`  | Check every box that is satisfied; leave unchecked anything not yet done. |
+### 4. Read the PR template
 
-5. **Output** — wrap the completed description in a fenced markdown code block tagged
-   `markdown` so the user can copy the raw text in one click:
+Read `.github/PULL_REQUEST_TEMPLATE.md` verbatim — this is the skeleton to fill in.
 
-   ````text
-   ```markdown
-   ## Description
-   …
-   ```
-   ````
+### 5. Derive the PR title
+
+The title **must** follow Conventional Commits format: `type(scope): subject`
+(imperative mood, no trailing period, ≤ 72 characters total).
+
+- If all commits share the same type and scope, use that type/scope directly.
+- If commits span multiple types, pick the dominant one (prefer `feat` > `fix` > others).
+- If commits span multiple scopes, omit the scope parenthetical.
+- The subject must be a concise imperative phrase summarising the PR, not a list of
+  commit subjects.
+- Examples: `feat(ci): add actionlint pre-commit hook`,
+  `fix(bootstrap): correct IAM policy for Lambda destroyer`
+
+### 6. Fill in the template
+
+Replace every `{{ placeholder }}` and populate every section:
+
+| Template section | What to write |
+|-----------------|---------------|
+| `## Description` | One concise paragraph: *what* changed and *why*. No implementation detail. |
+| `## Changes`    | Bulleted list of concrete changes (files, resources, modules). Name them. |
+| `## Testing`    | Check boxes that honestly apply; add a note if manual testing was done. |
+| `## Checklist`  | Check every box that is satisfied; leave unchecked anything not yet done. |
+
+### 7. Create and submit the PR
+
+Run `gh pr create` with the title and filled-in description:
+
+```bash
+gh pr create \
+  --base main \
+  --title "<PR title>" \
+  --body "$(cat <<'EOF'
+<filled PR description>
+EOF
+)"
+```
+
+After the command succeeds, output the PR URL returned by `gh pr create`.
 
 ## Quality rules
 
@@ -55,12 +109,14 @@ template at `.github/PULL_REQUEST_TEMPLATE.md`.
 - Keep the Description to ≤ 3 sentences.
 - The Changes list must use plain Markdown bullets (`-`), not numbered lists.
 - Preserve every HTML comment (`<!-- … -->`) from the template; do not delete them.
-- Do **not** commit or push anything.
+- Do **not** commit or amend any existing commits.
+- If `gh pr create` fails because the branch already has an open PR, report the existing
+  PR URL and stop — do not create a duplicate.
 
-## Example invocation
+## Example invocations
 
 ```text
 /pr-description
 ```
 
-Output is the filled template, ready to paste.
+Works from `main` (creates a branch) or from any feature branch.


### PR DESCRIPTION
<!-- pyml disable md041 -->
## Description

Enhances the `pr-description` skill to handle two starting states: when invoked from a feature branch it proceeds as before; when invoked from `main` it derives a Conventional Commits branch name from the unmerged commit subjects, creates and pushes the branch, then opens the PR via `gh pr create`. The PR title is now required to follow Conventional Commits format.

## Changes

- `.claude/skills/pr-description/SKILL.md`: added branch derivation and creation logic for `main` starting state, added `gh pr create` submission step, added Conventional Commits format requirement for PR title, extended `allowed-tools` with `git checkout`, `git push`, `gh pr create`, `gh pr view`

## Testing

<!-- Describe how the changes were tested (unit tests, manual, etc.). -->

- [ ] Unit tests added / updated
- [x] Manually verified — this PR was created by the skill itself

## Checklist

- [x] No secrets or credentials included
- [x] `make lint` passes locally