### PR TITLE
fix(docs): standardize AWS profile name to 'Cargonautica' across all files

### DIFF
--- a/.claude/plans/10-enable-cloudfront-distribution.md
+++ b/.claude/plans/10-enable-cloudfront-distribution.md
@@ -77,7 +77,7 @@ This provides equivalent security without consuming quota.
 **Solution:** Upload files to `s3://bucket/static/` prefix to match CloudFront's `/static/*` pattern. Created `assets/static/` directory for version control and sync to S3 with correct prefix using:
 
 ```bash
-aws s3 sync assets/static/ s3://bucket-name/static/ --profile cargonautica
+aws s3 sync assets/static/ s3://bucket-name/static/ --profile Cargonautica
 ```
 
 **Commit:** `cd9f405` - feat(static): add static content test files for CloudFront/S3
@@ -536,7 +536,7 @@ resource "cloudflare_dns_record" "www" {
 
 ```bash
 # Upload to S3 with correct prefix
-aws s3 sync assets/static/ s3://$(terraform output -raw s3_static_bucket_name)/static/ --profile cargonautica
+aws s3 sync assets/static/ s3://$(terraform output -raw s3_static_bucket_name)/static/ --profile Cargonautica
 ```
 
 **Note:** Files must be uploaded to `s3://bucket/static/` to match CloudFront's `/static/*` path pattern. The `assets/` directory contains source files for version control.
@@ -736,13 +736,13 @@ Static content is deployed from the `assets/static/` directory:
 ```bash
 # Static files are version controlled in assets/static/
 # Sync to S3 with correct prefix
-aws s3 sync assets/static/ s3://$(terraform output -raw s3_static_bucket_name)/static/ --profile cargonautica
+aws s3 sync assets/static/ s3://$(terraform output -raw s3_static_bucket_name)/static/ --profile Cargonautica
 
 # Invalidate CloudFront cache if content is updated
 aws cloudfront create-invalidation \
   --distribution-id $(terraform output -raw cloudfront_distribution_id) \
   --paths "/static/*" \
-  --profile cargonautica
+  --profile Cargonautica
 ```
 
 **Important:** Files must be uploaded to `s3://bucket/static/` to match CloudFront's `/static/*` path pattern.

--- a/.claude/scripts/aws-sso-credentials.sh
+++ b/.claude/scripts/aws-sso-credentials.sh
@@ -43,7 +43,7 @@ asc_extract_access_token() {
 
   if [[ -z "$access_token" ]] || [[ "$access_token" == "null" ]]; then
     echo "❌ Error: No valid SSO token found in cache" >&2
-    echo "   Run: aws sso login --profile cargonautica" >&2
+    echo "   Run: aws sso login --profile Cargonautica" >&2
     return 1
   fi
 
@@ -64,7 +64,7 @@ asc_get_role_credentials() {
     --region "$sso_region" 2>/dev/null) || {
     echo "❌ Error: Failed to get role credentials" >&2
     echo "   Your SSO session may have expired" >&2
-    echo "   Run: aws sso login --profile cargonautica" >&2
+    echo "   Run: aws sso login --profile Cargonautica" >&2
     return 1
   }
 

--- a/.claude/skills/aws/SKILL.md
+++ b/.claude/skills/aws/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: Bash(*/setup-aws-auth.sh), Bash(*/check-aws-auth.sh)
 
 ## Purpose
 
-This skill helps configure AWS authentication for the `cargonautica` AWS profile, supporting both AWS CLI commands and Terraform operations.
+This skill helps configure AWS authentication for the `Cargonautica` AWS profile, supporting both AWS CLI commands and Terraform operations.
 
 ## When to Use
 
@@ -34,7 +34,7 @@ This verifies if the current AWS authentication is valid.
 
 ```bash
 # Export AWS profile (preferred method)
-export AWS_PROFILE=cargonautica
+export AWS_PROFILE=Cargonautica
 
 # Verify it works
 aws sts get-caller-identity
@@ -45,7 +45,7 @@ aws sts get-caller-identity
 If SSO session is expired, prompt the user to run:
 
 ```bash
-aws sso login --profile cargonautica
+aws sso login --profile Cargonautica
 ```
 
 Then retry the authentication check.
@@ -65,7 +65,7 @@ source .claude/scripts/aws-sso-credentials.sh
 Most reliable for both AWS CLI and Terraform:
 
 ```bash
-export AWS_PROFILE=cargonautica
+export AWS_PROFILE=Cargonautica
 
 # AWS CLI automatically uses the profile
 aws s3 ls
@@ -95,12 +95,12 @@ See [@.claude/scripts/aws-sso-credentials.sh](../../scripts/aws-sso-credentials.
 **Resolution**: Inform user to re-authenticate:
 
 ```bash
-aws sso login --profile cargonautica
+aws sso login --profile Cargonautica
 ```
 
 ### Profile Not Found
 
-**Error**: `Profile cargonautica could not be found`
+**Error**: `Profile Cargonautica could not be found`
 
 **Resolution**: Verify AWS CLI configuration file (`~/.aws/config`) contains the profile definition.
 
@@ -109,7 +109,7 @@ aws sso login --profile cargonautica
 **Error**: `Unable to locate credentials`
 
 **Resolution**:
-1. Ensure `AWS_PROFILE=cargonautica` is exported
+1. Ensure `AWS_PROFILE=Cargonautica` is exported
 2. Check SSO session is valid with `aws sts get-caller-identity`
 3. Re-run SSO login if needed
 
@@ -126,8 +126,8 @@ aws sso login --profile cargonautica
 Terraform automatically uses `AWS_PROFILE` environment variable via the AWS SDK:
 
 ```bash
-export AWS_PROFILE=cargonautica
-terraform plan  # Uses cargonautica profile automatically
+export AWS_PROFILE=Cargonautica
+terraform plan  # Uses Cargonautica profile automatically
 ```
 
 No additional provider configuration needed in Terraform code when using profiles.

--- a/.claude/skills/aws/scripts/setup-aws-auth.sh
+++ b/.claude/skills/aws/scripts/setup-aws-auth.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Set up AWS authentication by exporting the cargonautica profile.
+# Set up AWS authentication by exporting the Cargonautica profile.
 #
 # Usage:
 #   source .claude/skills/aws/scripts/setup-aws-auth.sh

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Bootstrap infrastructure must be applied first — see [bootstrap/README.md](boo
 ## Usage
 
 ```bash
-export AWS_PROFILE=cargonautica
+export AWS_PROFILE=Cargonautica
 aws sso login
 
 # 1. Complete bootstrap setup (once)

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -85,10 +85,10 @@ out of sync with `pyproject.toml` — this is intentional and enforces reproduci
 
 **IMPORTANT**: Always use the `aws` skill to configure authentication before running AWS CLI commands or Terraform operations.
 
-When executing AWS CLI commands or Terraform, use the `cargonautica` AWS profile:
+When executing AWS CLI commands or Terraform, use the `Cargonautica` AWS profile:
 
 ```bash
-export AWS_PROFILE=cargonautica
+export AWS_PROFILE=Cargonautica
 aws sts get-caller-identity
 ```
 

--- a/modules/static-site/README.md
+++ b/modules/static-site/README.md
@@ -158,7 +158,7 @@ Upload static files to S3 at path `/static`:
 aws s3 sync ./assets/static/ \
   s3://ade-dev-static-381492075850/static/ \
   --delete \
-  --profile cargonautica
+  --profile Cargonautica
 
 # Invalidate CloudFront distribution cache
 aws cloudfront create-invalidation --distribution-id "$(terraform output -raw cloudfront_distribution_id)" --paths "/*"
@@ -174,7 +174,7 @@ When updating static files:
 aws cloudfront create-invalidation \
   --distribution-id E1E23QKYQBHFUB \
   --paths "/*" \
-  --profile cargonautica
+  --profile Cargonautica
 ```
 
 ## Monitoring


### PR DESCRIPTION
<!-- pyml disable md041 -->
## Description

Corrects the AWS profile name casing from `cargonautica` (lowercase) to `Cargonautica` (title case) across all documentation and scripts. The profile name is case-sensitive on macOS/Linux AWS CLI config, and `Cargonautica` is the authoritative spelling used in the working scripts.

## Changes

- `.claude/skills/aws/SKILL.md` — 9 profile name references updated
- `.claude/skills/aws/scripts/setup-aws-auth.sh` — comment on line 3 updated
- `.claude/scripts/aws-sso-credentials.sh` — 2 error-message `--profile` references updated
- `docs/ai-instructions.md` — profile name in prose and code block updated
- `README.md` — `export AWS_PROFILE=` updated
- `modules/static-site/README.md` — 2 `--profile` flag references updated
- `.claude/plans/10-enable-cloudfront-distribution.md` — 4 `--profile` flag references updated

## Testing

<!-- Describe how the changes were tested (unit tests, manual, etc.). -->

- [ ] Unit tests added / updated
- [x] Manually verified

## Checklist

- [x] No secrets or credentials included
- [x] `make lint` passes locally